### PR TITLE
Fix auth_tune var object types

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -39,11 +39,11 @@ variable "auth_tune" {
   type = object({
     default_lease_ttl            = optional(string)
     max_lease_ttl                = optional(string)
-    audit_non_hmac_response_keys = optional(string)
-    audit_non_hmac_request_keys  = optional(string)
+    audit_non_hmac_response_keys = optional(list(string))
+    audit_non_hmac_request_keys  = optional(list(string))
     listing_visibility           = optional(string)
-    passthrough_request_headers  = optional(string)
-    allowed_response_headers     = optional(string)
+    passthrough_request_headers  = optional(list(string))
+    allowed_response_headers     = optional(list(string))
     token_type                   = optional(string)
   })
   default = null


### PR DESCRIPTION
Error when trying to update auth_tune: https://app.terraform.io/app/sph/workspaces/platform-eng-vault-namespace-engr-dev/runs/run-743R1saaSmnvhNyJ