### PR TITLE
PFMENG-2553: Add global workload identity role

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,9 +10,9 @@ output "workspaces" {
       org       = v.org
       project   = v.project
       workspace = v.ws
-      role      = vault_jwt_auth_backend_role.roles[k].role_name
     },
     var.enable_identity_management ? {
+      role           = vault_jwt_auth_backend_role.roles[k].role_name
       identity_name  = vault_identity_entity.workspaces[k].name
       identity_id    = vault_identity_entity.workspaces[k].id
       identity_alias = vault_identity_entity_alias.workspaces[k].name

--- a/variables.tf
+++ b/variables.tf
@@ -126,3 +126,14 @@ variable "tfc_default_project" {
   type        = string
   default     = "Default Project"
 }
+
+variable "enable_global_identity" {
+  description = "Enable Identity Entity management globally. This creates a single entity for all workspaces per organization"
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_global_identity != var.enable_identity_management
+    error_message = "Global Identity management can only be enabled if Identity management is disabled"
+  }
+}


### PR DESCRIPTION
To use single role for TFC workload identity mainly to reduce the clients usage. 
- `enable_identity_management` - To be used when we need 1 role per TFC workspace.
- `enable_global_identity` - To be used when 1 role per TFC org. 